### PR TITLE
Implementation of when property to specify the condition for the SQA criteria execution

### DIFF
--- a/build/dist.yaml
+++ b/build/dist.yaml
@@ -424,6 +424,25 @@ components:
           example: tox.ini
       required:
         - testenv
+    When_branch:
+      type: object
+      properties:
+        pattern:
+          type: string
+        comparator:
+          type: string
+          enum:
+            - EQUALS
+            - GLOB
+            - REGEXP
+          default: GLOB
+      required:
+        - pattern
+      example:
+        branch:
+          pattern: release-\\d+
+    When_building_tag:
+      type: boolean
     CriterionBuild:
       type: object
       additionalProperties:
@@ -441,6 +460,13 @@ components:
                 tox:
                   $ref: '#/components/schemas/Tox_simplified'
               additionalProperties: false
+          when:
+            properties:
+              branch:
+                $ref: '#/components/schemas/When_branch'
+              building_tag:
+                $ref: '#/components/schemas/When_building_tag'
+            additionalProperties: false
       example:
         qc_style:
           repos:

--- a/openapi/components/schemas/CriterionBuild.yaml
+++ b/openapi/components/schemas/CriterionBuild.yaml
@@ -14,6 +14,13 @@ additionalProperties:
           tox:
             $ref: './Tox_simplified.yaml'
         additionalProperties: false
+    when:
+      properties:
+        branch:
+          $ref: './When_branch.yaml'
+        building_tag:
+          $ref: './When_building_tag.yaml'
+      additionalProperties: false
 example:
   qc_style:
     repos:

--- a/openapi/components/schemas/When_branch.yaml
+++ b/openapi/components/schemas/When_branch.yaml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  pattern:
+    type: string
+  comparator:
+    type: string
+    enum: [EQUALS, GLOB, REGEXP]
+    default: GLOB
+required:
+  - pattern
+example:
+  branch:
+    pattern: 'release-\\d+'

--- a/openapi/components/schemas/When_building_tag.yaml
+++ b/openapi/components/schemas/When_building_tag.yaml
@@ -1,0 +1,1 @@
+type: boolean


### PR DESCRIPTION
This change implements the support for establishing conditions for the execution of any given SQA criterion. It is based on the  Jenkins [when](https://www.jenkins.io/doc/book/pipeline/syntax/#when) clause.